### PR TITLE
Enable LocalStack lambda service for local workflow

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   localstack:
     image: localstack/localstack:2.3
     environment:
-      - SERVICES=s3
+      - SERVICES=s3,lambda
       - AWS_DEFAULT_REGION=us-east-1
       - EDGE_PORT=4566
       - DEBUG=1

--- a/local/README.md
+++ b/local/README.md
@@ -24,7 +24,9 @@ This directory contains helper assets for running the Serverless AI-Powered Imag
    docker compose up --build
    ```
 
-   Wait until both the `localstack` and `sagemaker` containers report as healthy.
+   Wait until both the `localstack` and `sagemaker` containers report as healthy. Ensure the LocalStack container is configured
+   with the Lambda API (e.g. `SERVICES=s3,lambda`) before proceeding. If you update the LocalStack configuration, recreate the
+   stack with `docker compose down` followed by `docker compose up --build` so the changes take effect.
 
 2. **Provision buckets**
 
@@ -62,7 +64,8 @@ This directory contains helper assets for running the Serverless AI-Powered Imag
      --mask-bucket "$MASK_BUCKET"
    ```
 
-   This script subscribes the two Lambda functions to the relevant S3 events through the AWS CLI.
+   This script subscribes the two Lambda functions to the relevant S3 events through the AWS CLI. The Lambda service must be
+   enabled in LocalStack before running this script.
 
 6. **Upload an image**
 


### PR DESCRIPTION
## Summary
- configure LocalStack to expose both the S3 and Lambda APIs so local Lambdas can be invoked
- document the requirement to enable the Lambda service and to recreate the stack after configuration updates

## Testing
- docker compose down *(fails: docker command not available in container)*
- docker compose up --build -d *(fails: docker command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cb0267c284832e842227da694d36ba