### PR TITLE
Fix local SAM build paths and env vars

### DIFF
--- a/local/sam-env.json
+++ b/local/sam-env.json
@@ -1,5 +1,6 @@
 {
   "TriggerSageMakerFunction": {
+    "SAGEMAKER_ENDPOINT_NAME": "local-rembg-endpoint",
     "SAGEMAKER_ENDPOINT_URL": "http://sagemaker:8080/invocations",
     "S3_ENDPOINT_URL": "http://localstack:4566",
     "AWS_REGION": "us-east-1",

--- a/template.yaml
+++ b/template.yaml
@@ -50,7 +50,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       FunctionName: !Sub "${AWS::StackName}-trigger-sagemaker"
-      CodeUri: ../lambdas/trigger_sagemaker/
+      CodeUri: lambdas/trigger_sagemaker/
       Handler: app.handler
       Description: Triggered by uploads to S3 and forwards images to SageMaker.
       Environment:
@@ -83,7 +83,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       FunctionName: !Sub "${AWS::StackName}-apply-masks"
-      CodeUri: ../lambdas/apply_masks/
+      CodeUri: lambdas/apply_masks/
       Handler: app.handler
       Description: Scales masks and creates the final processed images.
       Environment:


### PR DESCRIPTION
## Summary
- point the root SAM template at the in-repo Lambda source directories so `sam build` discovers the functions during local runs
- add a local SageMaker endpoint name to the SAM env file so the trigger Lambda can import successfully when started with `sam local`

## Testing
- not run (SAM CLI is unavailable in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68cb3168b59c832eb8eb9b8dd2312b9c