### PR TITLE
Allow configuring Lambda names for local event wiring

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ A dedicated [local guide](local/README.md) walks through standing up LocalStack,
 1. `docker compose up --build` to start LocalStack and the SageMaker mock service.
 2. `./local/setup-local.sh` to create the three S3 buckets in LocalStack.
 3. `sam build` and `sam local start-lambda` to run both Lambda functions inside Docker.
-4. `python local/wire_local_events.py` to connect S3 events to the locally running Lambdas.
+4. `python local/wire_local_events.py` (optionally with
+   `--trigger-function-name/--apply-function-name` overrides) to connect S3 events to the locally
+   running Lambdas.
 5. Upload a file to the upload bucket (via CLI or the frontend) and watch the pipeline finish end-to-end.
 
 ## Deploying to AWS

--- a/local/README.md
+++ b/local/README.md
@@ -62,7 +62,10 @@ This directory contains helper assets for running the Serverless AI-Powered Imag
      --mask-bucket "$MASK_BUCKET"
    ```
 
-   This script subscribes the two Lambda functions to the relevant S3 events through the AWS CLI.
+   This script subscribes the two Lambda functions to the relevant S3 events through the AWS CLI. If
+   you renamed the Lambda logical IDs in `template.yaml`, pass the new names via
+   `--trigger-function-name` and `--apply-function-name` so the helper connects to the expected
+   functions.
 
 6. **Upload an image**
 


### PR DESCRIPTION
## Summary
- allow `wire_local_events.py` to override the Lambda logical IDs via new CLI flags and use the provided names when wiring permissions
- include the resolved Lambda names and ARNs in the script's summary output
- document the new CLI overrides in the local development guides

## Testing
- python -m compileall local/wire_local_events.py

------
https://chatgpt.com/codex/tasks/task_e_68cb34b29e4c832e9751c63f4a021402